### PR TITLE
Fix error return codes for help messages.

### DIFF
--- a/ApigeePlatformTools/deploynodeapp.py
+++ b/ApigeePlatformTools/deploynodeapp.py
@@ -74,7 +74,7 @@ def run():
       ShouldDeploy = False
     elif o[0] == '-h':
       printUsage()
-      sys.exit(1)
+      sys.exit(0)
   
   BadUsage = False
   if Username == None:

--- a/ApigeePlatformTools/deployproxy.py
+++ b/ApigeePlatformTools/deployproxy.py
@@ -71,7 +71,7 @@ def run():
       ShouldDeploy = False
     elif o[0] == '-h':
       printUsage()
-      sys.exit(1)
+      sys.exit(0)
   
   if Username == None or Password == None or Directory == None or \
      Environment == None or Name == None or Organization == None:

--- a/ApigeePlatformTools/listdeployments.py
+++ b/ApigeePlatformTools/listdeployments.py
@@ -45,7 +45,7 @@ def run():
       ApigeeURL = o[1]
     elif o[0] == '-h':
       printUsage()
-      sys.exit(1)
+      sys.exit(0)
       
     
   if Username == None or Password == None or Organization == None:

--- a/ApigeePlatformTools/undeploy.py
+++ b/ApigeePlatformTools/undeploy.py
@@ -52,7 +52,7 @@ def run():
       ApigeeURL = o[1]
     elif o[0] == '-h':
       printUsage()
-      sys.exit(1)
+      sys.exit(0)
       
     
   if Username == None or Password == None or Organization == None or Name == None:


### PR DESCRIPTION
Just following the pattern from commit 4042c27bf117c24314110625b234f324d980a7db to fix the rest of the help message return codes.
