### PR TITLE
Add switch to allow deploy to HTTP/secure virtual host for deploynodeapp

### DIFF
--- a/ApigeePlatformTools/deploynodeapp.py
+++ b/ApigeePlatformTools/deploynodeapp.py
@@ -30,6 +30,7 @@ def printUsage():
   print '-l Apigee API URL (optional, defaults to https://api.enterprise.apigee.com)'
   print '-z ZIP file to save (optional for debugging)'
   print '-i import only, do not deploy'
+  print '-x set VirtualHost. Default value is default = http. Set to secure for https'
   print '-h Print this message'
   
 def run():    
@@ -44,8 +45,8 @@ def run():
   BasePath = '/'
   ShouldDeploy = True
   ZipFile = None
-    
-  Options = 'o:e:n:d:m:u:p:b:l:z:ih'
+  VirtualHost = 'default'
+  Options = 'o:e:x:n:d:m:u:p:b:l:z:ih'
   
   opts = getopt.getopt(sys.argv[2:], Options)[0]
   
@@ -70,6 +71,8 @@ def run():
       ApigeeURL = o[1]
     elif o[0] == '-z':
       ZipFile = o[1]
+    elif o[0] == '-x':
+      VirtualHost = o[1]
     elif o[0] == '-i':
       ShouldDeploy = False
     elif o[0] == '-h':
@@ -112,12 +115,12 @@ def run():
     return '<ProxyEndpoint name="default">\
       <HTTPProxyConnection>\
       <BasePath>%s</BasePath>\
-      <VirtualHost>default</VirtualHost>\
+      <VirtualHost>%s</VirtualHost>\
       </HTTPProxyConnection>\
       <RouteRule name="default">\
       <TargetEndpoint>default</TargetEndpoint>\
       </RouteRule>\
-      </ProxyEndpoint>' % BasePath
+      </ProxyEndpoint>' % (BasePath, VirtualHost)
       
   def makeTarget():
     return '<TargetEndpoint name="default">\

--- a/ApigeePlatformTools/deploytools.py
+++ b/ApigeePlatformTools/deploytools.py
@@ -13,9 +13,7 @@ def getBaseUrl(org, env, name, basePath, revision):
     
   response = httptools.httpCall('GET',
       '/v1/o/%s/apis/%s/revisions/%i/proxies/%s' % (org, name, revision, proxies[0]))
-
   proxy = json.load(response)
-
   if len(proxy['connection']['virtualHost']) < 1:
     # No virtual hosts
     return '(unknown)'

--- a/ApigeePlatformTools/deploytools.py
+++ b/ApigeePlatformTools/deploytools.py
@@ -13,7 +13,9 @@ def getBaseUrl(org, env, name, basePath, revision):
     
   response = httptools.httpCall('GET',
       '/v1/o/%s/apis/%s/revisions/%i/proxies/%s' % (org, name, revision, proxies[0]))
+
   proxy = json.load(response)
+
   if len(proxy['connection']['virtualHost']) < 1:
     # No virtual hosts
     return '(unknown)'
@@ -28,7 +30,12 @@ def getBaseUrl(org, env, name, basePath, revision):
   else:
     alias = vh['hostAliases'][0]
   
-  ret = 'http://%s:%s/' % (alias, vh['port'])
+  if vhName == 'secure' :
+    httpScheme = 'https'
+  else:
+    httpScheme = 'http'
+  
+  ret = httpScheme + '://%s:%s/' % (alias, vh['port'])
   if len(basePath) > 0:
     ret = urlparse.urljoin(ret, basePath)
   proxyBasePath = proxy['connection']['basePath']


### PR DESCRIPTION
- Update the help info to add new switch -x for Virtual host of proxy connection
- Add default value of 'default' to ensure this behaves as it did before if the new switch is omitted
- Update the deployment feedback to show the correct HTTP scheme (https://) when deployed to secure proxy
